### PR TITLE
Fix playerboard reset triggering game restart

### DIFF
--- a/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/playerboard/PlayerBoardFragment.kt
+++ b/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/playerboard/PlayerBoardFragment.kt
@@ -203,11 +203,11 @@ class PlayerBoardFragment : Fragment() {
                 "Yes",
                 "No")
             {
-                GameStateManager.resetGameScores()
+                viewModel.resetBoardCommand()
             }
         }
         else {
-            GameStateManager.resetGameScores()
+            viewModel.resetBoardCommand()
         }
     }
 

--- a/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/utils/GameStateManager.kt
+++ b/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/utils/GameStateManager.kt
@@ -220,7 +220,7 @@ object GameStateManager {
         addRoundScore(roundCounter.value ?: 1, player1CurrentPoints.value ?: 0, player2CurrentPoints.value ?: 0)
     }
 
-    fun resetGameScores() {
+    private fun resetGameScores() {
         setPlayer1CurrentPoints(0)
         setPlayer2CurrentPoints(0)
         resetRoundScores()


### PR DESCRIPTION
Fixes the bug where playerboard reset button acts as a restart button for the whole game