### PR TITLE
Empty Custom Name Bugfix

### DIFF
--- a/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/scoreboard/ScoreboardFragment.kt
+++ b/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/scoreboard/ScoreboardFragment.kt
@@ -123,7 +123,7 @@ class ScoreboardFragment : Fragment() {
             negativeButtonText = "Cancel")
         { inputText ->
             val resultText = inputText.trim()
-            if (resultText.length in 1..20) {
+            if (resultText.length in 1..15) {
                 if(isPlayer1)
                     GameStateManager.updateCustomPlayer1Name(inputText)
                 else

--- a/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/scoreboard/ScoreboardFragment.kt
+++ b/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/scoreboard/ScoreboardFragment.kt
@@ -122,11 +122,21 @@ class ScoreboardFragment : Fragment() {
             positiveButtonText = "OK",
             negativeButtonText = "Cancel")
         { inputText ->
-            if (inputText.length in 1..20) {
+            val resultText = inputText.trim()
+            if (resultText.length in 1..20) {
                 if(isPlayer1)
                     GameStateManager.updateCustomPlayer1Name(inputText)
                 else
                     GameStateManager.updateCustomPlayer2Name(inputText)
+            }
+            else if (resultText.isEmpty()) {
+                DialogUtils.showNotificationDialog(requireContext(),
+                    "Invalid Custom Name Length",
+                    "The name you entered is too short.\nAnd, by 'too short', I mean " +
+                            "it's literally nothing at all.",
+                    "Be better")
+                {
+                }
             }
             else {
                 DialogUtils.showNotificationDialog(requireContext(),

--- a/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/settings/SettingsFragment.kt
@@ -2,7 +2,9 @@ package com.askariya.lostcitiesscorecalculator.ui.settings
 
 import android.os.Bundle
 import android.text.InputFilter
+import android.widget.Toast
 import androidx.preference.EditTextPreference
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.askariya.lostcitiesscorecalculator.R
 
@@ -25,5 +27,26 @@ class SettingsFragment : PreferenceFragmentCompat() {
         player2NamePreference?.setOnBindEditTextListener { editText ->
             editText.filters = filterArray
         }
+
+        // Set up validation to prevent empty strings or whitespace
+        val nonEmptyStringValidator = Preference.OnPreferenceChangeListener { preference, newValue ->
+            val newName = newValue as? String
+            if (newName.isNullOrBlank()) {
+                // Show a message to the user (e.g., Toast or Dialog)
+                Toast.makeText(requireContext(), "Name cannot be empty or whitespace", Toast.LENGTH_SHORT).show()
+
+                // Reset the value to an empty string
+                if (preference is EditTextPreference) {
+                    preference.text = ""
+                }
+
+                false // Reject the change to prevent it from being saved
+            } else {
+                true // Accept the change
+            }
+        }
+
+        player1NamePreference?.onPreferenceChangeListener = nonEmptyStringValidator
+        player2NamePreference?.onPreferenceChangeListener = nonEmptyStringValidator
     }
 }

--- a/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/settings/SettingsFragment.kt
@@ -16,8 +16,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val player1NamePreference = findPreference<EditTextPreference>("player1name")
         val player2NamePreference = findPreference<EditTextPreference>("player2name")
 
-        // Set character limit (e.g., 10 characters) for player1name and player2name
-        val maxLength = 20
+        // Set character limit for player1name and player2name
+        val maxLength = 15
         val filterArray = arrayOf(InputFilter.LengthFilter(maxLength))
 
         player1NamePreference?.setOnBindEditTextListener { editText ->

--- a/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/utils/GameStateManager.kt
+++ b/app/src/main/java/com/askariya/lostcitiesscorecalculator/ui/utils/GameStateManager.kt
@@ -183,9 +183,12 @@ object GameStateManager {
         // Custom names was enabled
         if (useCustomNames) {
             val player1CustomName: String = (settingsSharedPreferences
-                .getString("player1name", DEFAULT_PLAYER_1_NAME) ?: DEFAULT_PLAYER_1_NAME).trim()
+                .getString("player1name", DEFAULT_PLAYER_1_NAME)?.takeIf { it.isNotBlank() }
+                ?: DEFAULT_PLAYER_1_NAME).trim()
+
             val player2CustomName: String = (settingsSharedPreferences
-                .getString("player2name", DEFAULT_PLAYER_2_NAME) ?: DEFAULT_PLAYER_2_NAME).trim()
+                .getString("player2name", DEFAULT_PLAYER_2_NAME)?.takeIf { it.isNotBlank() }
+                ?: DEFAULT_PLAYER_2_NAME).trim()
 
             // Set to custom name if necessary
             if (player1Name.value != player1CustomName)


### PR DESCRIPTION
Fixed bug where empty custom names could be entered
Added error messages for custom names of invalid length on scoreboard
Reduce max character limit to 15